### PR TITLE
small fix, rename bug fix

### DIFF
--- a/memori-app/src/lib/tauri/bindings.ts
+++ b/memori-app/src/lib/tauri/bindings.ts
@@ -146,7 +146,7 @@ export type MemoriLayout =
  * │                 │
  * └─────────────────┘
  */
-{ full: WidgetId } | 
+{ Full: WidgetId } | 
 /**
  * ┌────────┬────────┐
  * │        │        │
@@ -156,7 +156,7 @@ export type MemoriLayout =
  * │        │        │
  * └────────┴────────┘
  */
-{ vsplit: { left: WidgetId; right: WidgetId } } | 
+{ VSplit: { left: WidgetId; right: WidgetId } } | 
 /**
  * ┌─────────────────┐
  * │                 │
@@ -168,7 +168,7 @@ export type MemoriLayout =
  * │                 │
  * └─────────────────┘
  */
-{ hsplit: { top: WidgetId; bottom: WidgetId } } | 
+{ HSplit: { top: WidgetId; bottom: WidgetId } } | 
 /**
  * ┌──────┬──────────┐
  * │      │          │
@@ -180,7 +180,7 @@ export type MemoriLayout =
  * │      │  Bottom  │
  * └──────┴──────────┘
  */
-{ vsplitWithRightHSplit: { left: WidgetId; right_top: WidgetId; right_bottom: WidgetId } } | 
+{ VSplitWithRightHSplit: { left: WidgetId; rightTop: WidgetId; rightBottom: WidgetId } } | 
 /**
  * ┌────────┬────────┐
  * │        │        │
@@ -192,7 +192,7 @@ export type MemoriLayout =
  * │     Bottom      │
  * └─────────────────┘
  */
-{ hsplitWithTopVSplit: { bottom: WidgetId; top_right: WidgetId; top_left: WidgetId } } | 
+{ HSplitWithTopVSplit: { bottom: WidgetId; topRight: WidgetId; topLeft: WidgetId } } | 
 /**
  * ┌──────────┬──────┐
  * │          │      │
@@ -204,7 +204,7 @@ export type MemoriLayout =
  * │  Bottom  │      │
  * └──────────┴──────┘
  */
-{ vsplitWithLeftHSplit: { left_top: WidgetId; left_bottom: WidgetId; right: WidgetId } } | 
+{ VSplitWithLeftHSplit: { leftTop: WidgetId; leftBottom: WidgetId; right: WidgetId } } | 
 /**
  * ┌─────────────────┐
  * │                 │
@@ -217,7 +217,7 @@ export type MemoriLayout =
  * │  Left  │ Right  │
  * └────────┴────────┘
  */
-{ hsplitWithBottomVSplit: { top: WidgetId; bottom_left: WidgetId; bottom_right: WidgetId } } | 
+{ HSplitWithBottomVSplit: { top: WidgetId; bottomLeft: WidgetId; bottomRight: WidgetId } } | 
 /**
  * ┌────────┬────────┐
  * │        │        │
@@ -229,7 +229,7 @@ export type MemoriLayout =
  * │  Left  │ Right  │
  * └────────┴────────┘
  */
-{ fourths: { top_left: WidgetId; top_right: WidgetId; bottom_left: WidgetId; bottom_right: WidgetId } }
+{ Fourths: { topLeft: WidgetId; topRight: WidgetId; bottomLeft: WidgetId; bottomRight: WidgetId } }
 export type MemoriStateInput = { activeFrameIdx: number; widgets: MemoriWidget[]; frames: MemoriLayout[]; frameTime: number }
 export type MemoriWidget = { id: WidgetId; kind: WidgetKind; remoteUpdateFrequency: UpdateFrequency; localUpdateFrequency: UpdateFrequency }
 /**

--- a/memori-app/src/routes/device/+page.svelte
+++ b/memori-app/src/routes/device/+page.svelte
@@ -6,17 +6,14 @@
     requestLocationState,
   } from '@/features/prefs/service.ts'
   import { prefsState } from '@/features/prefs/store.ts'
-  import { commands, events, type DeviceMode, tryCmd } from '@/tauri'
-  // import { Window } from '@tauri-apps/api/window'
+  import { commands, type DeviceMode, tryCmd } from '@/tauri'
   import { Button } from '$lib/components/ui/button/index.js'
   import * as Field from '$lib/components/ui/field/index.js'
   import { Input } from '$lib/components/ui/input/index.js'
 
-  // const appWindow = new Window('theUniqueLabel')
-
-  events.updateIsConnected.listen((e) => {
-    console.log('listening', e)
-  })
+  // events.updateIsConnected.listen((e) => {
+  //   console.log('listening', e)
+  // })
 
   type PendingAction =
     | 'connect'

--- a/memori-ui/src/layout.rs
+++ b/memori-ui/src/layout.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all_fields = "camelCase")]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
-#[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
 pub enum MemoriLayout {
     /// ┌─────────────────┐
     /// │                 │
@@ -18,6 +17,7 @@ pub enum MemoriLayout {
     /// │                 │
     /// │                 │
     /// └─────────────────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     Full(WidgetId),
 
     /// ┌────────┬────────┐
@@ -27,6 +27,7 @@ pub enum MemoriLayout {
     /// │        │        │
     /// │        │        │
     /// └────────┴────────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     VSplit { left: WidgetId, right: WidgetId },
 
     /// ┌─────────────────┐
@@ -38,6 +39,7 @@ pub enum MemoriLayout {
     /// │     Bottom      │
     /// │                 │
     /// └─────────────────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     HSplit { top: WidgetId, bottom: WidgetId },
 
     /// ┌──────┬──────────┐
@@ -49,6 +51,7 @@ pub enum MemoriLayout {
     /// │      │  Right   │
     /// │      │  Bottom  │
     /// └──────┴──────────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     VSplitWithRightHSplit {
         left: WidgetId,
         right_top: WidgetId,
@@ -64,6 +67,7 @@ pub enum MemoriLayout {
     /// │                 │
     /// │     Bottom      │
     /// └─────────────────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     HSplitWithTopVSplit {
         bottom: WidgetId,
         top_right: WidgetId,
@@ -79,6 +83,7 @@ pub enum MemoriLayout {
     /// │   Left   │      │
     /// │  Bottom  │      │
     /// └──────────┴──────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     VSplitWithLeftHSplit {
         left_top: WidgetId,
         left_bottom: WidgetId,
@@ -95,6 +100,7 @@ pub enum MemoriLayout {
     /// │ Bottom │ Bottom │
     /// │  Left  │ Right  │
     /// └────────┴────────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     HSplitWithBottomVSplit {
         top: WidgetId,
         bottom_left: WidgetId,
@@ -110,6 +116,7 @@ pub enum MemoriLayout {
     /// │ Bottom │ Bottom │
     /// │  Left  │ Right  │
     /// └────────┴────────┘
+    #[cfg_attr(feature = "specta", specta(rename_all = "camelCase"))]
     Fourths {
         top_left: WidgetId,
         top_right: WidgetId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns MemoriLayout names between Rust and TypeScript to fix a serialization/rename mismatch, preventing layout parsing errors. Also cleans up an unused device event listener.

- **Bug Fixes**
  - TypeScript bindings: renamed MemoriLayout variants to PascalCase (e.g., Full, VSplit, HSplit, Fourths) and fields to camelCase (e.g., rightTop, topRight, bottomLeft).
  - Rust (memori-ui): moved specta rename to per-variant with rename_all = "camelCase" to ensure generated bindings match TS; removed enum-level specta rename.
  - Device page: removed unused events import and listener.

<sup>Written for commit fb5524a6288e4c87a47eb6755d537e46f58aad7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

