### PR TITLE
accidentally forgot to commit this to the PR, adding now

### DIFF
--- a/memori-app/src-tauri/src/widget_data/github_data.rs
+++ b/memori-app/src-tauri/src/widget_data/github_data.rs
@@ -1,11 +1,25 @@
 use reqwest::Client;
-use serde::Deserialize;
 use chrono::{Local, Datelike};
 use tauri::AppHandle;
 use tauri_plugin_svelte::ManagerExt;
 use crate::oauth::UserInfo;
 use std::collections::HashMap;
 use memori_ui::widgets::Github;
+
+async fn github_get(client: &Client, url: &str, token: &str) -> Result<serde_json::Value, String> {
+    client
+        .get(url)
+        .bearer_auth(token)
+        .header("User-Agent", "my-app")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .error_for_status()
+        .map_err(|e| e.to_string())?
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|e| e.to_string())
+}
 
 async fn get_num_prs(
     token: &str,
@@ -14,56 +28,21 @@ async fn get_num_prs(
 ) -> Result<u32, String> {
     let client = Client::new();
     let url = format!(
-        "https://api.github.com/repos/{}/{}/pulls?state=open&per_page=100",
+        "https://api.github.com/search/issues?q=repo:{}/{}+type:pr+state:open&per_page=1",
         username, repo
     );
-    let response = client
-        .get(&url)
-        .bearer_auth(token)
-        .header("User-Agent", "my-app")
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
+    let data = github_get(&client, &url, token).await?;
+    let count = data["total_count"].as_u64().ok_or_else(|| "total_count not found".to_string())? as u32;
 
-    #[derive(Deserialize)]
-    struct PullRequest {
-        id: u64,
-    }
-
-    let prs = response
-        .json::<Vec<PullRequest>>()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    Ok(prs.len() as u32)
+    Ok(count)
 }
 
-async fn get_num_stars(
-    token: &str,
-    username: &str,
-    repo: &str,
-) -> Result<u32, String> {
+async fn get_num_stars(token: &str, username: &str, repo: &str) -> Result<u32, String> {
     let client = Client::new();
-    let url = format!(
-        "https://api.github.com/repos/{}/{}",
-        username, repo
-    );
-    let response = client
-        .get(&url)
-        .bearer_auth(token)
-        .header("User-Agent", "my-app")
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    #[derive(Deserialize)]
-    struct Repo {
-        stargazers_count: u32,
-    }
-
-    let repo = response.json::<Repo>().await.map_err(|e| e.to_string())?;
-
-    Ok(repo.stargazers_count)
+    let url = format!("https://api.github.com/repos/{}/{}", username, repo);
+    let data = github_get(&client, &url, token).await?;
+    let stars = data["stargazers_count"].as_u64().unwrap_or(0) as u32;
+    Ok(stars)
 }
 
 async fn get_num_issues(token: &str, username: &str, repo: &str) -> Result<u32, String> {
@@ -72,55 +51,22 @@ async fn get_num_issues(token: &str, username: &str, repo: &str) -> Result<u32, 
         "https://api.github.com/search/issues?q=repo:{}/{}+type:issue+state:open&per_page=1",
         username, repo
     );
-    let response = client
-        .get(&url)
-        .bearer_auth(token)
-        .header("User-Agent", "my-app")
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    #[derive(Deserialize)]
-    struct SearchResult {
-       total_count: u32, 
-    }
-    
-    let status = response.status();
-    if !status.is_success() {
-        return Err(format!("Failed to fetch issues: status {}", status));
-    }
-    
-    let result = response.json::<SearchResult>().await.map_err(|e| e.to_string())?;
-    Ok(result.total_count)
-}
-
-async fn get_num_notifications(token: &str) -> Result<u32, String> {
-    let client = Client::new();
-    let response = client
-        .get("https://api.github.com/notifications")
-        .bearer_auth(token)
-        .header("User-Agent", "my-app")
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    let notifications = response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(|e| e.to_string())?;
-    let count = notifications
-        .as_array()
-        .map(|a| a.len() as u32)
-        .unwrap_or(0);
+    let data = github_get(&client, &url, token).await?;
+    let count = data["total_count"].as_u64().unwrap_or(0) as u32;
     Ok(count)
 }
 
-pub async fn get_commit_frequency(
-    token: &str,
-    owner: &str,
-    repo: &str,
-) -> Result<[u32; 7], String> {
+
+async fn get_num_notifications(token: &str) -> Result<u32, String> {
     let client = Client::new();
+    let data = github_get(&client, "https://api.github.com/notifications", token).await?;
+    let count = data.as_array().map(|a| a.len() as u32).unwrap_or(0);
+    Ok(count)
+}
+
+async fn get_commit_frequency(token: &str, owner: &str, repo: &str) -> Result<[u32; 7], String> {
     let mut commits_per_day = Vec::new();
+    let client = Client::new();
 
     for i in (1..=7).rev() {
         let since = (Local::now() - chrono::Duration::days(i))
@@ -133,23 +79,13 @@ pub async fn get_commit_frequency(
             "https://api.github.com/repos/{}/{}/commits?since={}&until={}",
             owner, repo, since, until
         );
-        let response = client
-            .get(&url)
-            .bearer_auth(&token)
-            .header("User-Agent", "my-app")
-            .send()
-            .await
-            .map_err(|e| e.to_string())?;
-        let commits = response
-            .json::<serde_json::Value>()
-            .await
-            .map_err(|e| e.to_string())?;
-        let count = commits.as_array().map(|a| a.len() as u32).unwrap_or(0);
+
+        let data = github_get(&client, &url, token).await?;
+        let count = data.as_array().map(|a| a.len() as u32).unwrap_or(0);
         commits_per_day.push(count);
     }
-    
+
     let commits_arr: [u32; 7] = commits_per_day.try_into().unwrap();
-    
     Ok(commits_arr)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored GitHub data fetching to use a shared request helper, reducing duplication and improving error handling. Also fixed open PR counting to return accurate totals beyond 100.

- **Refactors**
  - Added github_get helper (auth, User-Agent, error_for_status, JSON parse).
  - Simplified stars, issues, notifications, and commit frequency to reuse helper.
  - Removed ad-hoc response structs; made get_commit_frequency internal.

- **Bug Fixes**
  - get_num_prs now uses the search API total_count (not capped at 100).

<sup>Written for commit 278d1a89a604f0c7767497c4b349400cc47d5ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

